### PR TITLE
Using the correct NonUniqueResultException class

### DIFF
--- a/kiss-querydsl-mockery/src/main/java/com/marvinformatics/kiss/querydslmockery/JPQLMockeryQuery.java
+++ b/kiss-querydsl-mockery/src/main/java/com/marvinformatics/kiss/querydslmockery/JPQLMockeryQuery.java
@@ -5,12 +5,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.persistence.NonUniqueResultException;
-
 import com.marvinformatics.kiss.querydslmockery.impl.AbstractQueryBase;
 import com.marvinformatics.kiss.querydslmockery.impl.MockeryQueryTemplates;
 import com.mysema.query.DefaultQueryMetadata;
 import com.mysema.query.JoinType;
+import com.mysema.query.NonUniqueResultException;
 import com.mysema.query.SearchResults;
 import com.mysema.query.Tuple;
 import com.mysema.query.collections.CollQueryMixin;

--- a/kiss-querydsl-mockery/src/test/java/com/marvinformatics/kiss/querydslmockery/JPQLMockeryQueryTest.java
+++ b/kiss-querydsl-mockery/src/test/java/com/marvinformatics/kiss/querydslmockery/JPQLMockeryQueryTest.java
@@ -7,7 +7,6 @@ import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
-import javax.persistence.NonUniqueResultException;
 import javax.persistence.Persistence;
 
 import org.hamcrest.MatcherAssert;
@@ -21,6 +20,7 @@ import com.marvinformatics.kiss.querydslmockery.entity.Address;
 import com.marvinformatics.kiss.querydslmockery.entity.Person;
 import com.marvinformatics.kiss.querydslmockery.entity.QAddress;
 import com.marvinformatics.kiss.querydslmockery.entity.QPerson;
+import com.mysema.query.NonUniqueResultException;
 import com.mysema.query.SearchResults;
 import com.mysema.query.Tuple;
 import com.mysema.query.jpa.JPQLQuery;


### PR DESCRIPTION
It was using the javax.persistence class, but queryDSL throws an instance
of its own exception
